### PR TITLE
Fix for marshalling magento modules

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/DeployManager.php
+++ b/src/MagentoHackathon/Composer/Magento/DeployManager.php
@@ -98,13 +98,9 @@ class DeployManager
         );
     }
 
-
-    public function doDeploy($installedLocalPackages = array())
+    public function doDeploy()
     {
         $this->sortPackages();
-        $packageCount = count($this->packages);
-        $installedLocalPackagesCount = count($installedLocalPackages);
-        $installedPackages = [];
 
         /** @var Entry $package */
         foreach ($this->packages as $package) {
@@ -112,21 +108,6 @@ class DeployManager
                 $this->io->write('start magento deploy for ' . $package->getPackageName());
             }
             $package->getDeployStrategy()->deploy();
-            $installedPackages [$package->getPackageName()] = $package->getPackageName();
-        }
-        if (!empty($installedLocalPackages) && $packageCount !== $installedLocalPackagesCount) {
-            $packageTypes = PackageTypes::$packageTypes;
-            foreach ($installedLocalPackages as $package) {
-                if (!isset($installedPackages[$package->getName()]) && isset($packageTypes[$package->getType()])) {
-                    if ($this->io->isDebug()) {
-                        $this->io->write('Updating missing packages ' . $package->getName());
-                    }
-                    $strategy = $this->getInstaller()->getDeployStrategy($package);
-                    $strategy->setMappings($this->getInstaller()->getParser($package)->getMappings());
-                    $strategy->deploy();
-                }
-            }
-
         }
     }
 }

--- a/src/MagentoHackathon/Composer/Magento/DeployManager.php
+++ b/src/MagentoHackathon/Composer/Magento/DeployManager.php
@@ -33,11 +33,6 @@ class DeployManager
      */
     protected $sortPriority = array();
 
-    /**
-     * @var Installer
-     */
-    private $installer;
-
     public function __construct(IOInterface $io)
     {
         $this->io = $io;
@@ -53,18 +48,6 @@ class DeployManager
     {
         $this->sortPriority = $priorities;
     }
-
-
-    public function setInstaller(Installer $installer)
-    {
-        $this->installer = $installer;
-    }
-
-    public function getInstaller()
-    {
-        return $this->installer;
-    }
-
 
     /**
      * uses the sortPriority Array to sort the packages.

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -59,11 +59,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     protected $filesystem;
 
-    /**
-     * @var array PackageInterface
-     */
-    protected $installedPackages = [];
-
     protected function initDeployManager(Composer $composer, IOInterface $io)
     {
         $this->deployManager = new DeployManager($io);
@@ -145,10 +140,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         if ($this->io->isDebug()) {
             $this->io->write('start magento deploy via deployManager');
         }
-        $command = $event->getName();
-        $this->installedPackages = $event->getComposer()->getRepositoryManager()->getLocalRepository()->getPackages();
-        $this->deployManager->setInstaller($this->installer);
-        $this->deployManager->doDeploy($this->installedPackages);
+
+        $this->deployManager->doDeploy();
         $this->deployLibraries();
         $this->saveVendorDirPath($event->getComposer());
     }


### PR DESCRIPTION
MAGETWO-34212: Updating Magento fails when sample data previously installed
MAGETWO-34551: magento composer tries to deploy installed modules

- removed logic which tries to iterate all modules and do deploy in case if it is magento component even if it is already deployed.