### PR TITLE
wrong relative path for symlinks

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
@@ -140,7 +140,7 @@ class Symlink extends DeploystrategyAbstract
             array_shift($dir);
         }
 
-        $relativePath = str_repeat('../', count($dir)) . implode('/', $file);
+        $relativePath = str_repeat('../', count($dir)-1) . implode('/', $file);
         return $relativePath;
     }
 }


### PR DESCRIPTION
I have the following mapping in my module's composer.json:

```
"extra": {
    "map": [
      [
        "src",
        "Flancer32/Sample"
      ]
    ]
},
```

The result of the getRelativePath(...) is

```
../../../../../vendor/flancer32/sample_mage2_module/src
```

but should be

```
../../../../vendor/flancer32/sample_mage2_module/src
```
