### PR TITLE
Removing environment specific switch from tool

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer.php
@@ -175,10 +175,6 @@ class Installer extends LibraryInstaller implements InstallerInterface
             $this->isForced = (bool)$extra['magento-force'];
         }
 
-        if (false !== getenv('MAGENTO_CLOUD_PROJECT')) {
-            $this->setDeployStrategy('none');
-        }
-
         if (isset($extra['magento-deploystrategy'])) {
             $this->setDeployStrategy((string)$extra['magento-deploystrategy']);
         }


### PR DESCRIPTION
Toolchains should work uniformly regardless of what environment they are run within. That is, with the same settings, composer should do the same things everywhere it is run.

Should someone not want file-marshaling to run when deploying Magento ECE, they should add `"magento-deploystrategy": "none"` to the `extra` section of their composer config. 

In a recent setup where I prepped an existing site to deploy into the ECE environment, I was forced to explicitly request the use of the `copy` strategy in my composer.json (using same setting as noted above) to workaround this seemingly arbitrary condition which was added to this module at the behest of the platform.sh and/or Magento team(s).