### PR TITLE
Add __constructor 3rd parameter's default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Magento Composer Installer
 
-This is a fork of the [Magento Composer Installer](https://github.com/magento-hackathon/magento-composer-installer) repo that provides support for Magento 2 components (modules, themes, language packages, libraries and components).
+This is a fork of [Magento's fork](https://github.com/magento/magento-composer-installer) of Magento Hackathon composer package to be able to address some installation issues that one might encounter due to some code changes VS the original module.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Magento Composer Installer
 
-This is a fork of [Magento's fork](https://github.com/magento/magento-composer-installer) of Magento Hackathon composer package to be able to address some installation issues that one might encounter due to some code changes VS the original module.
+This is a fork of the [Magento Composer Installer](https://github.com/magento-hackathon/magento-composer-installer) repo that provides support for Magento 2 components (modules, themes, language packages, libraries and components).
 
 ## Usage
 

--- a/src/MagentoHackathon/Composer/Magento/ModmanParser.php
+++ b/src/MagentoHackathon/Composer/Magento/ModmanParser.php
@@ -25,7 +25,7 @@ class ModmanParser extends PathTranslationParser
      *
      * @param string $moduleDir
      */
-    public function __construct($moduleDir = null, $translations = array(), $pathSuffix)
+    public function __construct($moduleDir = null, $translations = array(), $pathSuffix = '')
     {
         parent::__construct($translations, $pathSuffix);
 


### PR DESCRIPTION
Encountered an error when upgrading to Magento EE 2.1.6 relates to the fact that under certain considtions Modman parser will have no contructor arguments defined (which used to be expected in the original module that magento team has forked). Due to that module stating that it's a replacement for magento-hackathon module, I would expect the __construct setup to remain intact for it to really serve as areplacement. Therefore, a default value was introduced for the third argument.

```
- Installing colinmollenhour/cache-backend-file (1.4)
  Loading from cache
[ErrorException]
Missing argument 3 for MagentoHackathon\Composer\Magento\ModmanParser::__construct(), called in phar:///usr/local/bin/composer/src/Composer/Plugi
n/PluginManager.php(195) : eval()'d code on line 318 and defined
```