### PR TITLE
Fix failed to composer install in module directory

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -320,7 +320,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 return '$vendorDirPath';
 
 AUTOLOAD;
-        $this->filesystem->ensureDirectoryExists($vendorPathFile);
+        $this->filesystem->ensureDirectoryExists($magentoDir . '/app/etc/');
         file_put_contents($vendorPathFile, $content);
     }
 

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -320,6 +320,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 return '$vendorDirPath';
 
 AUTOLOAD;
+        $this->filesystem->ensureDirectoryExists($vendorPathFile);
         file_put_contents($vendorPathFile, $content);
     }
 


### PR DESCRIPTION
# Issue

Cannot composer install or require in module directory if one of the dependencies hook up with magento composer installer.

# Bug reproduction

1. Have an `awesome/module-a` to hook up with the installer

```
{
    "name": "awesome/module-a",
    // ...
    "type": "magento2-component",
    "extra": {
        "map": [
            [
                "lib",
                "lib"
            ]
        ]
    }
}
```

2. Have an awesome/module-b to require module-a

```
{
    "name": "awesome/module-b",
    // ...
    "require": {
        "magento/framework": "^100.0.1"
    },
    // ....
}
```

```
composer require awesome/module-a
```

### Expected Result

composer require success

### Actual Result

```
[ErrorException]                                                                                                                                                       
  file_put_contents(app/etc/vendor_path.php): failed to open stream: No such file or directory  
```
