### PR TITLE
Provide clearer error on broken symlink

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -30,11 +30,11 @@ class Copy extends DeploystrategyAbstract
 
 
         // Create all directories up to one below the target if they don't exist
-        $destDir = dirname($destPath);
+        $destDir = realpath(dirname($destPath));
+        if (empty($destDir)) {
+            throw new \ErrorException("Target directory $destDir is a broken symlink");
+        }
         if (!file_exists($destDir)) {
-            if (is_link($destDir)) {
-                throw new \ErrorException("Target directory $destDir is a broken symlink");
-            }
             mkdir($destDir, 0777, true);
         }
 

--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -32,6 +32,9 @@ class Copy extends DeploystrategyAbstract
         // Create all directories up to one below the target if they don't exist
         $destDir = dirname($destPath);
         if (!file_exists($destDir)) {
+            if (is_link($destDir)) {
+                throw new \ErrorException("Target directory $destDir is a broken symlink");
+            }
             mkdir($destDir, 0777, true);
         }
 


### PR DESCRIPTION
Right now if a containing directory of a mapped path is a broken symlink, this module will try to create it on top of the symlink leading to this unclear message:

    mkdir(): File exists

This provides a more explicit error in that case.

I feel that ideally there would be a way to force this to continue even in this scenario, but I'm not sure that the regular `"magento-force": "override"` should be overloaded to also take care of overwriting the parent directory of the mapped file.