### PR TITLE
MAGETWO-90865: Remove code from the package 'magento/magento-composer-installer' that use deployment strategy based on environment variable

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer.php
@@ -175,10 +175,6 @@ class Installer extends LibraryInstaller implements InstallerInterface
             $this->isForced = (bool)$extra['magento-force'];
         }
 
-        if (false !== getenv('MAGENTO_CLOUD_PROJECT')) {
-            $this->setDeployStrategy('none');
-        }
-
         if (isset($extra['magento-deploystrategy'])) {
             $this->setDeployStrategy((string)$extra['magento-deploystrategy']);
         }


### PR DESCRIPTION
# Description
https://jira.corp.magento.com/browse/MAGETWO-90865
You no longer need to change the strategy for deploying Magento Cloud projects depending on the environment variable MAGENTO_CLOUD_PROGECT