### PR TITLE
Added check for mapped components which are linked

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -71,6 +71,13 @@ class Copy extends DeploystrategyAbstract
 
         // From now on $destPath can't be a directory, that case is already handled
 
+        // Check if the $desthPath is a symbolic link
+        if(is_link($destPath)){
+            echo "Target $dest already exists as sym link and will therefor not be updated\n";
+
+            return true;
+        }
+        
         // If file exists and force is not specified, throw exception unless FORCE is set
         if (file_exists($destPath)) {
             if ($this->isForced()) {


### PR DESCRIPTION
Deployment breaks when part of the files/folders are a symbolic link.

For example when having the pub/media folder as a softlink. Deployment will never add the folder /setup to the Magento installation folder. Since the mkdir command at line 103 (after proposed change), will generate an error