### PR TITLE
Fix too many files being ignored when providing an ignore path containing directories

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
@@ -208,7 +208,7 @@ abstract class DeploystrategyAbstract
         $destination = str_replace('/./','/', $destination);
         $destination = str_replace('//','/', $destination);
         foreach($this->ignoredMappings as $ignored){
-            if( 0 === strpos($ignored,$destination) ){
+            if( 0 === strpos($destination,$ignored) ){
                 return true;
             }
         }


### PR DESCRIPTION
Problem: Providing an ignore path to "magento-deploy-ignore" containing directories causes other files in those directories to be ignored. 

Set of steps that I used to reproduce the problem:
1. Install Magento B2B module.
2. Add these lines to "magento-deploy-ignore" in composer.json. For those curious, this is being done on a project because its composer installation removes the NegotiableQuote module (and several others, a la https://github.com/yireo/magento2-replace-tools) but the B2B base module has this Negotiable Quote fixture file. Its presence breaks setup:di:compile. This project does not use integration tests so this fixture file's absence will not be missed. This is of course one example to reproduce the problem. There are likely other better examples that do not have other solutions:
```
        "magento-deploy-ignore": {
            ...
            "magento/magento2-b2b-base": [
                "/setup/src/Magento/Setup/Fixtures/NegotiableQuotesFixture.php"
            ]
        },
```
3. `rm -rf setup vendor/magento/magento2-base/ vendor/magento/magento2-b2b-base && composer install`
4. See that other files are being ignored:

```
setup/src/Magento/Setup/Test/Unit/Fixtures/NegotiableQuotesFixtureTest.php
setup/src/Magento/Setup/Test/Unit/Fixtures/CompaniesFixtureTest.php
setup/src/Magento/Setup/Fixtures/_files/quote_fixture_data.json
setup/src/Magento/Setup/Fixtures/NegotiableQuotesFixture.php
setup/src/Magento/Setup/Fixtures/Quote/NegotiableQuoteConfiguration.php
setup/src/Magento/Setup/Fixtures/CompaniesFixture.php
setup/src/Magento/Setup/Fixtures/SharedCatalogsFixture.php
setup/performance-toolkit/files/1mb.pdf
setup/performance-toolkit/profiles/b2b
setup/performance-toolkit/profiles/b2b/extra_small.xml
setup/performance-toolkit/profiles/b2b/manufacture_standard.xml
setup/performance-toolkit/profiles/b2b/small.xml
setup/performance-toolkit/profiles/b2b/singlesite_small.xml
setup/performance-toolkit/profiles/b2b/medium.xml
```

This is because, in the `strpos($destination,$ignored` code, `$destination` is these values:

```
/setup/src/Magento
/setup/src/Magento/Setup
/setup/src/Magento/Setup/Test
/setup/src/Magento/Setup/Test/Unit
/setup/src/Magento/Setup/Test/Unit/Fixtures
/setup/src/Magento/Setup/Test/Unit/Fixtures/NegotiableQuotesFixtureTest.php
/setup/src/Magento/Setup/Test/Unit/Fixtures/CompaniesFixtureTest.php
/setup/src/Magento/Setup/Fixtures/_files
/setup/src/Magento/Setup/Fixtures/_files/quote_fixture_data.json
/setup/src/Magento/Setup/Fixtures/NegotiableQuotesFixture.php
/setup/src/Magento/Setup/Fixtures/Quote
/setup/src/Magento/Setup/Fixtures/Quote/NegotiableQuoteConfiguration.php
/setup/src/Magento/Setup/Fixtures/CompaniesFixture.php
/setup/src/Magento/Setup/Fixtures/SharedCatalogsFixture.php
```

strpos( '/setup/src/Magento/Setup/Fixtures/SharedCatalogsFixture.php', '/setup') returns 0, so the entire setup folder is ignored! This is because strpos takes the haystack as the first argument, not the second. So the arguments are reversed. 

This seems like a significant change, so I hope that this will be well-reviewed. I am surprised that this bug exists but maybe this use case is rarer than I assumed, or this change will cause some other unintended effect or break some major use case that I am unaware of. The bug does go unnoticed for simple ignores not containing directories, e.g. "/.gitignore", "/.editorconfig", etc. 