### PR TITLE
Laminas\Stdlib for glob compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     ],
     "require": {
         "composer-plugin-api": "^1.1 || ^2.0",
-        "composer/composer": "^1.9 || ^2.0"
+        "composer/composer": "^1.9 || ^2.0",
+        "laminas/laminas-stdlib": "^3.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
@@ -5,6 +5,8 @@
 
 namespace MagentoHackathon\Composer\Magento\Deploystrategy;
 
+use Laminas\Stdlib\Glob;
+
 /**
  * Abstract deploy strategy
  */
@@ -342,7 +344,7 @@ abstract class DeploystrategyAbstract
     protected function removeContentOfCategory($sourcePath, $destPath)
     {
         $sourcePath = preg_replace('#/\*$#', '/{,.}*', $sourcePath);
-        $matches = glob($sourcePath, GLOB_BRACE);
+        $matches = Glob::glob($sourcePath, Glob::GLOB_BRACE);
         if ($matches) {
             foreach ($matches as $match) {
                 if (preg_match("#/\.{1,2}$#", $match)) {


### PR DESCRIPTION
On Linux distributions like Alpine GLOB_BRACE is not available, which is a known issue.

An elegant workaround is to use Laminas\Stdlib instead of PHP's native glob() function. Will create a PR which hopefully gets accepted to solve this annoying issue.